### PR TITLE
version bump node-RED 1.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: shell
 
 env:
     global:
-        - NODE_RED_BASE_TAG=1.1.1
+        - NODE_RED_BASE_TAG=1.1.2
         - QEMU_VERSION=v4.0.0
         - S6_VERSION=v1.22.1.0
         - DOCKER_FILE=Dockerfile.alpine

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-homekit-docker",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Node-RED nodes to simulate Apple HomeKit devices.",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -18,7 +18,7 @@
         }
     ],
     "dependencies": {
-        "node-red": "1.1.1",
+        "node-red": "1.1.2",
         "node-red-contrib-homekit-bridged": "1.1.1"
     },
     "engines": {


### PR DESCRIPTION
This feature bumps node-RED to version 1.1.2