### PR TITLE
Fix broken `WORKDIR`.

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -40,7 +40,17 @@ ARG FFMPEG_OS
 
 # vcgencmd
 RUN case "$FFMPEG_OS" in \
-    raspbian) set -x && apk add --no-cache cmake && git clone https://github.com/raspberrypi/utils.git && cd utils/vcgencmd && cmake . && make && make install && cd ../.. && rm -r utils \
+    raspbian) \
+      set -x && \
+      apk add --no-cache cmake && \
+      git clone https://github.com/raspberrypi/utils.git && \
+      cd utils/vcgencmd && \
+      cmake . && \
+      make && \
+      make install && \
+      cd ../.. && \
+      rm -r utils \
+      ;; \
     esac
 
 # s6 overlay

--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -23,7 +23,6 @@ LABEL org.label-schema.build-date=${BUILD_DATE} \
 USER root
 
 RUN apk update
-WORKDIR /build
 
 # root filesystem
 COPY rootfs /
@@ -41,7 +40,7 @@ ARG FFMPEG_OS
 
 # vcgencmd
 RUN case "$FFMPEG_OS" in \
-    raspbian) set -x && apk add --no-cache cmake; git clone https://github.com/raspberrypi/utils.git; cd utils/vcgencmd; cmake .; make; make install; \
+    raspbian) set -x && apk add --no-cache cmake && git clone https://github.com/raspberrypi/utils.git && cd utils/vcgencmd && cmake . && make && make install && cd ../.. && rm -r utils \
     esac
 
 # s6 overlay


### PR DESCRIPTION
Keep `WORKDIR` as `/usr/src/node-red`, otherwise additional packages aren't actually found.